### PR TITLE
Updated shared_preferences version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
     sdk: flutter
 
   http: ^0.12.0+2
-  shared_preferences: ^0.5.3+1
+  shared_preferences: ^2.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
I've updated shared_preferences version to 2.0.3, because it was causing the problem while migrating dart's null aware feature.