### PR TITLE
Fix CORS problem on Flutter Web

### DIFF
--- a/lib/src/mixpanel_analytics.dart
+++ b/lib/src/mixpanel_analytics.dart
@@ -371,9 +371,7 @@ class MixpanelAnalytics {
     }
 
     try {
-      final response = await http.get(Uri.parse(url), headers: {
-        'Content-type': 'application/json',
-      });
+      final response = await http.get(Uri.parse(url));
       return response.statusCode == 200 &&
           _validateResponseBody(url, response.body);
     } on Exception catch (error) {


### PR DESCRIPTION
Fix the following error on browsers
```
Access to XMLHttpRequest at 'https://api.mixpanel.com/track/?data=...&verbose=1&ip=0' from origin 'https://some.domain' has been blocked by CORS policy: Request header field content-type is not allowed by Access-Control-Allow-Headers in preflight response.
```

Changes:
Remove 'Content-type' header from GET requests