### PR TITLE
fix(cors): Reintroduce fix in #20 in combination with optionalHeaders

### DIFF
--- a/lib/src/mixpanel_analytics.dart
+++ b/lib/src/mixpanel_analytics.dart
@@ -392,7 +392,7 @@ class MixpanelAnalytics {
     }
 
     try {
-      final headers = {'Content-type': 'application/json'};
+      final headers = <String, String>{};
 
       if (_optionalHeaders?.isNotEmpty ?? false) {
         headers.addAll(_optionalHeaders!);


### PR DESCRIPTION
#20 removed the Content-Type header due to Cors issues.
This fix was lost when integrating the flutter-1 changes adding optionalHeaders.

This PR should solve both use-cases.