### PR TITLE
feat(baseApi): support for custom baseApiUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.1.0] - 2021-06-22
+
+- Support to add a custom base api url. This basically allows the user to use EU-based web servers as stated in [here](https://developer.mixpanel.com/docs/privacy-security#storing-your-data-in-the-european-union). We're not hardcoding the EU-based url in case Mixpanel considers to add support for more regions.
+
 ## [2.0.3] - 2021-06-22
 
 - Fix userId stream type. The `userId` property can be null.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: mixpanel_analytics
 description:
   A dart wrapper on the mixpanel REST API to be used in Flutter applications.
   As this is using the http REST API it works both with Android and iOS.
-version: 2.0.3
+version: 2.1.0
 homepage: https://github.com/Alpha-health/mixpanel_analytics
 repository: https://github.com/Alpha-health/mixpanel_analytics
 issue_tracker: https://github.com/Alpha-health/mixpanel_analytics/issues

--- a/test/mixpanel_analytics_test.dart
+++ b/test/mixpanel_analytics_test.dart
@@ -43,8 +43,9 @@ void main() {
     return base64;
   }
 
-  Uri buildGetRequest(String operation, Object event) => Uri.parse(
-      '${MixpanelAnalytics.baseApi}/$operation/?data=${base64Encoder(event)}&verbose=0&ip=0');
+  Uri buildGetRequest(String operation, Object event, String baseApiUrl) =>
+      Uri.parse(
+          '$baseApiUrl/$operation/?data=${base64Encoder(event)}&verbose=0&ip=0');
 
   void stubGet(Response response) {
     when(http.get(any, headers: anyNamed('headers')))
@@ -81,15 +82,19 @@ void main() {
         () async {
       stubGet(Response(fakeResponseNoVerbose['ok']!, 200));
 
-      final expected = buildGetRequest('track', {
-        'event': 'random event',
-        'properties': {
-          'key': 'value',
-          'token': 'some-mixpanel-token',
-          'time': 1561130182320,
-          'distinct_id': 'some-user-id',
+      final expected = buildGetRequest(
+        'track',
+        {
+          'event': 'random event',
+          'properties': {
+            'key': 'value',
+            'token': 'some-mixpanel-token',
+            'time': 1561130182320,
+            'distinct_id': 'some-user-id',
+          },
         },
-      });
+        sut.baseApiUrl,
+      );
 
       final success = await sut.track(
         event: 'random event',
@@ -111,12 +116,16 @@ void main() {
         () async {
       stubGet(Response(fakeResponseNoVerbose['ok']!, 200));
 
-      final expected = buildGetRequest('engage', {
-        '\$set': {'key': 'value'},
-        '\$token': 'some-mixpanel-token',
-        '\$time': 1561130182320,
-        '\$distinct_id': 'some-user-id',
-      });
+      final expected = buildGetRequest(
+        'engage',
+        {
+          '\$set': {'key': 'value'},
+          '\$token': 'some-mixpanel-token',
+          '\$time': 1561130182320,
+          '\$distinct_id': 'some-user-id',
+        },
+        sut.baseApiUrl,
+      );
 
       final success = await sut.engage(
         operation: MixpanelUpdateOperations.$set,


### PR DESCRIPTION
This PR adds the ability to use a custom baseApiUrl so the user can customize the api endpoint. A clear use case is mentioned in #25

fixes #25